### PR TITLE
Actually read keys from options

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ const quote = (val) =>
 
 const weasyprint = async (input, options, callback) => {
   let child;
-  const keys = [];
   const args = [weasyprint.command];
 
   if (!options) {
@@ -24,8 +23,7 @@ const weasyprint = async (input, options, callback) => {
   delete options.output;
   delete options.swnOptn;
 
-  console.log("options", options);
-
+  const keys = Object.keys(options)
   // make sure the special keys are last
 
   if (!options.debug) {


### PR DESCRIPTION
While building command line options for the weasyprint command, an empty array of keys was always used. This fixes that by reading the keys to be transformed to options from the actual options object.